### PR TITLE
Fix for label carrier animation to adjust to font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
-- None
+- Now clearing the code clears also the textfield and set the current label to 0 so we can start writing again. Added by [@ramiroleandrodiaz](https://github.com/ramiroleandrodiaz)
 
 ### Fixed
 
-- None
+- Now the carrier animation adjusts to the font size. Added by [@ramiroleandrodiaz](https://github.com/ramiroleandrodiaz)
 
 ## [0.4.0] The Cleaning Release 🧹
 

--- a/Sources/FasterVerificationCode/VerificationCodeFields.swift
+++ b/Sources/FasterVerificationCode/VerificationCodeFields.swift
@@ -31,7 +31,7 @@ open class VerificationCodeLabel: UILabel
         super.init(coder: aDecoder)
     }
 
-	public convenience init(_ frame: CGRect, isBordered: Bool, borderColor: UIColor, borderHeight: CGFloat, tintColor: UIColor, backgroundColor: UIColor = .white)
+    public convenience init(_ frame: CGRect, isBordered: Bool, borderColor: UIColor, borderHeight: CGFloat, tintColor: UIColor, backgroundColor: UIColor = .white, font: UIFont?)
     {
         self.init(frame: frame)
         self.heightAnchor.constraint(equalToConstant: frame.height).isActive = true
@@ -42,6 +42,7 @@ open class VerificationCodeLabel: UILabel
         self.isBordered = isBordered
 		self.borderHeight = borderHeight
 		self.borderColor = borderColor
+        self.font = font
         addCarrierView()
     }
 

--- a/Sources/FasterVerificationCode/VerificationCodeView.swift
+++ b/Sources/FasterVerificationCode/VerificationCodeView.swift
@@ -138,6 +138,7 @@ open class VerificationCodeView: UIView
         }
         hiddenTextField.text = ""
         currentLabel = 0
+        openKeyboard()
     }
 
     private func addLabelsToStackView()

--- a/Sources/FasterVerificationCode/VerificationCodeView.swift
+++ b/Sources/FasterVerificationCode/VerificationCodeView.swift
@@ -136,6 +136,8 @@ open class VerificationCodeView: UIView
         for label in labels {
             label.text = ""
         }
+        hiddenTextField.text = ""
+        currentLabel = 0
     }
 
     private func addLabelsToStackView()

--- a/Sources/FasterVerificationCode/VerificationCodeView.swift
+++ b/Sources/FasterVerificationCode/VerificationCodeView.swift
@@ -144,8 +144,7 @@ open class VerificationCodeView: UIView
     {
         for _ in 1...numberOfLabel
         {
-			let label = VerificationCodeLabel(CGRect(x: 0, y: 0, width: labelWidth, height: self.frame.height), isBordered: labelHasBorder, borderColor: labelBorderColor, borderHeight: borderHeigth, tintColor: labelTintColor, backgroundColor: labelBackgroundColor)
-            label.font = labelFont
+			let label = VerificationCodeLabel(CGRect(x: 0, y: 0, width: labelWidth, height: self.frame.height), isBordered: labelHasBorder, borderColor: labelBorderColor, borderHeight: borderHeigth, tintColor: labelTintColor, backgroundColor: labelBackgroundColor, font: labelFont)
 			label.textColor = labelTextColor
             labelContainer.addArrangedSubview(label)
             labels.append(label)


### PR DESCRIPTION
Hi @posix88, I found out that the view for the carrier animation was set up during carrier view in here:

` private func addCarrierView()
    {
        carrierView = UIView(frame: CGRect(x: 0, y: 0, width: 2, height: self.font.pointSize))
`

And this was called when the verification code field was initialised, hence it doesn't have the loaded font. After that, in the VerificaitionCodeView, you set the font after initialising the label (in addLabelsToStackView method) but the font does **not** affect the carrier view, since it was already initialised.

I fixed that by simply passing the font as a parameter during the verificaitionCodeLabel init method.

Also, in this PR I fixed something I did earlier that was clearing the code, but I didn't clear the textfield nor the currentLabel number so I could not re enter the code once it was cleared!

Hope you like it, In that case let me know if you want to release it!